### PR TITLE
Support for Privacy API, From & To status, Reply-to and bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,37 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-## [1.1.1] - 2016-05-12 and 2017-10-29 and 2018-04-30
+## [1.2.0] - 2018-05-20
+### Added
+- privacy:metadata string.
+- More answers in FAQ section of README.md.
+- From and To addresses in status message.
+- Support for Reply-to.
+### Updated
+- Fixed a PHP notice that rarely but did occur when reloading the results page without going through the form again.
+- Documentation.
+- phpDocs error.
+
+## [1.1.3] - 2018-04-30
+No code changes.
+### Updated
+- Moodle eMailTest has been successfully tested for compatibility with Moodle 2.5 to 3.5.
+- More answers in FAQ section of README.md.
+- Documentation.
+- Copyright for 2018.
+
+## [1.1.2] - 2017-10-29
+No code changes.
+### Updated
+- Moodle eMailTest has been successfully tested for compatibility with Moodle 2.5 to 3.3.
+
+## [1.1.1] - 2016-05-12
 No code changes.
 ### Added
 - CONTRIBUTE.md.
 ### Updated
 - Removed Limitations notice in the README.md file. This plugin is confirmed to work with PHP 7.1 (thanks davidpesce)
-- Moodle eMailTest has been successfully tested for compatibility with Moodle 2.5 to 3.5.
+- Moodle eMailTest has been successfully tested for compatibility with Moodle 2.5 to 3.3.
 - Reorganized README.md (New: logo, status badges, table of contents, contributing, etc).
 
 ## [1.1.0] - 2016-02-03
@@ -18,6 +42,7 @@ No code changes.
 - New option to send from primary admin user's email address.
 - Now displays Moodle informative debug messages from email_to_user().
 - Added more answers to FAQ section of documentation relating to cron and Moodle 3.2+.
+
 
 ## [1.0.1] - 2016-01-02
 ### Updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,14 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-## [1.2.0] - 2018-05-20
+## [1.2.1] - 2018-05-21
 ### Added
-- privacy:metadata string.
+- Support for Privacy API.
 - More answers in FAQ section of README.md.
 - From and To addresses in status message.
-- Support for Reply-to.
+- Support for Reply-to address.
 ### Updated
-- Fixed a PHP notice that rarely but did occur when reloading the results page without going through the form again.
+- Fixed a PHP notice that rarely but occasionally occurred when reloading the results page without going through the form again.
 - Documentation.
 - phpDocs error.
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Install the plugin, like any other plugin, to the following folder:
 
     /local/mailtest
 
-See http://docs.moodle.org/34/en/Installing_plugins for details on installing Moodle plugins.
+See http://docs.moodle.org/35/en/Installing_plugins for details on installing Moodle plugins.
 
 There are no special considerations required for updating the plugin.
 
@@ -172,9 +172,9 @@ typically in your server's PHP.INI file. If you do configure the SMTP
 settings in Moodle, it will attempt to deliver emails directly to the
 SMTP server.
 
-### How can I use this tool to send emails to other email addresses?
+### How can I use this tool to send emails from other email addresses?
 
-You can't at the moment. If you really must, you can temporarily test the email address of one of the following "From" addresses:
+You can't. This is to prevent the tool from being used to send spam. If you really must, you can temporarily test the email address of one of the following "From" addresses:
 
 * Your user account
 * Support
@@ -187,13 +187,17 @@ As of Moodle 3.2, use of the no-reply email address is no longer optional in man
 
 ### Why do I see a message about cron not having run for at least 24 hours?
 
-IMPORTANT - See https://docs.moodle.org/34/en/Cron . If a link is included within the message, clicking it will cause Moodle to try sending queued messages immediately. However, future message will still not be sent automatically. Clicking the link instead of configuring cron will just hide the notice for 24 hours after which it will return until you fix this issue.
+IMPORTANT - See https://docs.moodle.org/35/en/Cron . If a link is included within the message, clicking it will cause Moodle to try sending queued messages immediately. However, future message will still not be sent automatically. Clicking the link instead of configuring cron will just hide the notice for 24 hours after which it will return until you fix this issue.
 
 If for some reason you are unable to setup an automated cron job and don't see the link, you can enable the link and allow remote running of the cron job by going to Site administration >Security > Site Policies and unchecking **Cron execution via command line only**. For a little extra security, also set a **Cron password for remote access**.
 
 ### Why do I see some debugging code in the communications log even though debugging is turned off?
 
 Moodle does some validation before sending an email and can display some useful information so we've enabled some minimal display of debugging information. Informative lines start with **email_to_user**. You can ignore the line number references that follow the information line.
+
+### Regardless of which "from" email address I use, the test email always arrives from the same email address. Why?
+
+This is likely a setting in your mail server. To confirm which email address was used to send the email, look at the bottom of the status message after you try to send the email. If the test email was successfully delivered, you can also try to reply to the test message and take a look at the To email address. There is no need to actually send the reply. 
 
 ### Are there any security considerations?
 

--- a/class/privacy/provider.php
+++ b/class/privacy/provider.php
@@ -15,26 +15,33 @@
 // along with eMailTest.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Main form for eMailTest.
+ * Privacy Subsystem implementation for local_mailtest.
  *
  * @package    local_mailtest
- * @copyright  2016-2018 TNG Consulting Inc. - www.tngconsulting.ca
+ * @copyright  2015-2018 TNG Consulting Inc. - www.tngcosulting.ca
  * @author     Michael Milette
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die;
+namespace local_mailtest\privacy;
+
+defined('MOODLE_INTERNAL') || die();
 
 /**
- * Upgrade code for the eMailTest local plugin.
+ * Privacy Subsystem for local_mailtest implementing null_provider.
  *
- * @param int $oldversion - the version we are upgrading from.
- * @return bool result
+ * @copyright  2018 TNG Consulting Inc. <www.tngconsulting.ca>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-function xmldb_local_mailtest_upgrade($oldversion) {
+class provider implements \core_privacy\local\metadata\null_provider {
 
-    // Moodle v2.6.0 release upgrade line.
-    // Upgrade steps below.
-
-    return true;
+    /**
+     * Get the language string identifier with the component's language
+     * file to explain why this plugin stores no data.
+     *
+     * @return  string
+     */
+    public static function get_reason() : string {
+        return 'privacy:metadata';
+    }
 }

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -29,7 +29,6 @@ defined('MOODLE_INTERNAL') || die;
  * Upgrade code for the eMailTest local plugin.
  *
  * @param int $oldversion
- * @param object $block
  */
 function xmldb_local_mailtest_upgrade($oldversion) {
 

--- a/index.php
+++ b/index.php
@@ -132,7 +132,9 @@ if (!$data) { // Display the form.
     $form->display();
 
 } else {      // Send test email.
-
+    if (!isset($data->sender)) {
+        $data->sender = $CFG->noreplyaddress;
+    }
     $fromemail = local_mailtest_generate_email_user($data->sender);
 
     if ($CFG->branch >= 26) {
@@ -174,7 +176,7 @@ if (!$data) { // Display the form.
     $CFG->debugdisplay = true;
     $CFG->debugsmtp = true;
     ob_start();
-    $success = email_to_user($toemail, $fromemail, $subject, $messagetext, $messagehtml, '', '', true);
+    $success = email_to_user($toemail, $fromemail, $subject, $messagetext, $messagehtml, '', '', true, $fromemail->email);
     $smtplog = ob_get_contents();
     ob_end_clean();
     $CFG->debug = $debuglevel;
@@ -192,6 +194,8 @@ if (!$data) { // Display the form.
         } else {
             $msg = get_string('sentmail', 'local_'.$pluginname);
         }
+        $msg .= '<br><br>' . get_string('from') . ' : ' . $fromemail->email . '<br>' . get_string('to') . ' : '. $toemail->email;
+
         local_mailtest_msgbox($msg, get_string('success'), 2, 'infobox', $url);
 
     } else { // Failed to deliver message to the SMTP mail server.
@@ -209,6 +213,8 @@ if (!$data) { // Display the form.
         } else {
             $msg = get_string($errstring, 'local_'.$pluginname, '../../admin/settings.php?section=messagesettingemail');
         }
+        $msg .= '<br><br>' . get_string('from') . ' : ' . $fromemail->email . '<br>' . get_string('to') . ' : '. $toemail->email;
+
         local_mailtest_msgbox($msg, get_string('emailfail', 'error'), 2, 'errorbox', $url);
 
     }

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_mailtest';  // To check on upgrade, that module sits in correct place
-$plugin->version   = 2017051900;        // The current module version (Date: YYYYMMDDXX)
+$plugin->version   = 2017052000;        // The current module version (Date: YYYYMMDDXX)
 $plugin->requires  = 2013040500;        // Requires Moodle version 2.5.
 $plugin->release   = '1.2';
 $plugin->maturity  = MATURITY_STABLE;

--- a/version.php
+++ b/version.php
@@ -26,8 +26,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_mailtest';  // To check on upgrade, that module sits in correct place
-$plugin->version   = 2017052000;        // The current module version (Date: YYYYMMDDXX)
+$plugin->version   = 2018052100;        // The current module version (Date: YYYYMMDDXX)
 $plugin->requires  = 2013040500;        // Requires Moodle version 2.5.
-$plugin->release   = '1.2';
+$plugin->release   = '1.2.1';
 $plugin->maturity  = MATURITY_STABLE;
 $plugin->cron      = 0;

--- a/version.php
+++ b/version.php
@@ -26,8 +26,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_mailtest';  // To check on upgrade, that module sits in correct place
-$plugin->version   = 2017020200;        // The current module version (Date: YYYYMMDDXX)
+$plugin->version   = 2017051900;        // The current module version (Date: YYYYMMDDXX)
 $plugin->requires  = 2013040500;        // Requires Moodle version 2.5.
-$plugin->release   = '1.1';
+$plugin->release   = '1.2';
 $plugin->maturity  = MATURITY_STABLE;
 $plugin->cron      = 0;


### PR DESCRIPTION
## [1.2.1] - 2018-05-21
### Added
- Support for Privacy API.
- More answers in FAQ section of README.md.
- From and To addresses in status message.
- Support for Reply-to address.
### Updated
- Fixed a PHP notice that rarely but occasionally occurred when reloading the results page without going through the form again.
- Documentation.
- phpDocs error.
