### PR TITLE
& to &amp; issue resolve

### DIFF
--- a/index.php
+++ b/index.php
@@ -170,7 +170,7 @@ if (!$data) { // Display the form.
     }
     $toemail = local_mailtest_generate_email_user($toemail, '');
 
-    $subject = format_string($SITE->fullname);
+    $subject = $SITE->fullname;
 
     // Add some system information.
     $a = new stdClass();


### PR DESCRIPTION
Any organisation having & in the site name getting &amp; in the email test, resolved by removing the format_string.